### PR TITLE
fix: remove version field to solve docker compose warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 x-common: &default
   restart: unless-stopped
   logging:


### PR DESCRIPTION
docker compose 2.25.0 开始，如果 compose 文件中有 `version` 字段，会有一个警告；

```shell
WARN[0000] /home/he-sb/dozzle/docker-compose.yml: `version` is obsolete
```

因为 docker compose v1 版本是通过 python 程序 docker-compose 调用的，从 v2 版本开始已经用 go 实现，并且集成为 docker 的子命令，不再需要这个字段了。

参考 https://github.com/jasonacox/Powerwall-Dashboard/issues/453#issuecomment-2008619928